### PR TITLE
Fixed required namespace for ServiceAccounts

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: mukube-loadbalancer
-version: v0.1.0
+version: v0.1.1
 maintainers:
   - name: Jacob Crawford
 

--- a/chart/templates/metallb.yaml
+++ b/chart/templates/metallb.yaml
@@ -205,6 +205,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller
+  namespace: {{.Release.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -219,6 +220,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: speaker
+  namespace: {{.Release.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -294,7 +296,7 @@ spec:
         - name: METALLB_ML_LABELS
           value: "app=metallb,component=speaker"
         - name: METALLB_ML_NAMESPACE
-          value: {{.Release.namespace}}
+          value: {{.Release.Namespace}}
         - name: METALLB_ML_SECRET_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
ServiceAccounts are namespaced objects, and therefore the namespace field is required. 

Error is thrown when trying to install helm chart:
ClusterRoleBinding.rbac.authorization.k8s.io "metallb-system:speaker" is invalid: subjects[0].namespace: Required value